### PR TITLE
Remove deprecated loop argument

### DIFF
--- a/src/snug/clients.py
+++ b/src/snug/clients.py
@@ -126,7 +126,7 @@ async def _asyncio_send(loop, req, *, timeout=10, max_redirects=10):
     url = urllib.parse.urlsplit(
         req.url + "?" + urllib.parse.urlencode(req.params)
     )
-    open_ = partial(asyncio.open_connection, url.hostname, loop=loop)
+    open_ = partial(asyncio.open_connection, url.hostname)
     connect = open_(443, ssl=True) if url.scheme == "https" else open_(80)
     reader, writer = await connect
     try:


### PR DESCRIPTION
DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.